### PR TITLE
Changed modified color to work better with light themes

### DIFF
--- a/line-reminder.el
+++ b/line-reminder.el
@@ -51,7 +51,7 @@
                  (const :tag "indicators" indicators)))
 
 (defface line-reminder-modified-sign-face
-  `((t :foreground "#EFF284"))
+  `((t :foreground "#DDE165"))
   "Modifed sign face."
   :group 'line-reminder)
 


### PR DESCRIPTION
This is just tweaking the modified color to work better with light themes. With the current color set I was having a hard time seeing it with my theme (cattpuccin-latte) and didn't notice it was there until I saved. Below is a link to the pictures of what it looked like with my theme before, and what it looks like now in both light and dark themes. I couldn't figure out how to upload an image so I just uploaded them to imgur, hope that's okay!

https://imgur.com/a/GK4fTFZ