### PR TITLE
fix: avoid right fringe post-command crash

### DIFF
--- a/line-reminder.el
+++ b/line-reminder.el
@@ -277,8 +277,7 @@ If optional argument THUMBNAIL is non-nil, return in thumbnail faces."
          (ov (make-overlay (line-beginning-position) (line-end-position)))
          (window (selected-window)))
     (when (eq fringe 'right-fringe)
-      (put-text-property (line-beginning-position) (1+ (line-beginning-position))
-                         'cursor t display-string))
+      (put-text-property 0 1 'cursor t display-string))
     (ov-set ov
             'after-string display-string
             'line-reminder-window window


### PR DESCRIPTION
## Summary

This fixes the `args-out-of-range` crash reported in #36.

The right-fringe TTY rendering path in `line-reminder--create-tty-ov` was calling `put-text-property` with buffer positions against `display-string`, which is just a short string. Switching that call to string-relative indices matches the existing thumbnail helper and avoids the crash.

## Verification

- Reproduced the failing path before the change and saw `(args-out-of-range 1 2)`.
- Re-ran the same reproduction after the change and it now returns `OK`.
- Re-ran the left-fringe indicator path and it still returns `OK`.
- Byte-compiled `line-reminder.el` successfully.

## Notes

`make ci` could not be run in my local environment because `eask` is not installed there.

Closes #36.
